### PR TITLE
feat(graphql-mocks)!: resolve mockOperation data from the mock graph

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -23,7 +23,7 @@ Key facts:
 - `MockResult.toResolvers()`: Produce Apollo Server / GraphQL Yoga mock resolvers (`{ Type: () => <random item from pool> }`) for `addMocksToSchema`.
 - `MockResult.dataForOperation(document, variables?)`: Execute a query/mutation against the graph and return data shaped to the selection set (lists, fragments, and interface/union fields supported). Return type inferred from a `TypedDocumentNode`.
 - `mockOperation(query, data, options?)` / `mockOperationVariants(...)`: Build Apollo `MockedProvider` `MockedResponse` entries from supplied result data (`options`: `variables`, `delay`, `error`, `maxUsageCount`).
-- `mockOperationFromPool(mocks, query, options?)` / `mockOperationVariantsFromPool(...)`: Same, but resolve the result data from a `MockResult` graph (via `dataForOperation`) so the query's selection set selects the mocks — no data argument needed.
+- `MockResult.mockOperation(query, options?)` / `MockResult.mockOperationVariants(...)`: Same, but resolve the result data from the `MockResult` graph (via `dataForOperation`) so the query's selection set selects the mocks — no data argument needed.
 - `BuildMocksOptions`: `count`, `faker`, `seed`, `nullChance`, `scalars`, `overrides`, `resolveType`, `addTypename`, `stableIds`.
 - `@vantreeseba/graphql-mocks-codegen` plugin: emits `export type SchemaTypeMap = { … }` for every object type (root operation and introspection types excluded, entries sorted).
 
@@ -37,7 +37,7 @@ Key facts:
 - Interfaces/unions: `buildMocks(schema, { resolveType: (name) => name === 'SearchResult' ? 'Post' : 'User' })`.
 - Typed pools: `buildMocks<{ User: User; Todo: Todo }>(schema)` or `buildMocks<SchemaTypeMap>(schema)`.
 - Operation data: `const data = mocks.dataForOperation(UserByIdQuery)` → `{ user: { …selected fields, nested via wired refs… } }`.
-- Apollo MockedProvider (data from the graph): `<MockedProvider mocks={[mockOperationFromPool(mocks, AwardByIdQuery)]} />`.
+- Apollo MockedProvider (data from the graph): `<MockedProvider mocks={[mocks.mockOperation(AwardByIdQuery)]} />`.
 
 ## Optional
 

--- a/packages/graphql-mocks/README.md
+++ b/packages/graphql-mocks/README.md
@@ -125,23 +125,23 @@ const data = mocks.dataForOperation(UserByIdQuery);
 
 These helpers turn a `TypedDocumentNode` into an entry for Apollo's `MockedProvider` `mocks` array — no hand-written `request`/`result` boilerplate.
 
-The `*FromPool` variants need **no data argument at all**: they resolve the result straight from a `MockResult` graph (via `dataForOperation`), so the query's own selection set decides which mocks come back. Point them at the same `mocks` you built from the schema:
+Call them off the `mocks` graph (`mocks.mockOperation`) and you need **no data argument at all**: the result is resolved straight from the graph (via `dataForOperation`), so the query's own selection set decides which mocks come back. The pool is already captured, so you just pass the document:
 
 ```tsx
 import { MockedProvider } from '@apollo/client/testing';
-import { buildMocks, mockOperationFromPool } from '@vantreeseba/graphql-mocks';
+import { buildMocks } from '@vantreeseba/graphql-mocks';
 import { AwardByIdQuery } from './graphql';
 
 const mocks = buildMocks<SchemaTypeMap>(schema);
 
 render(
-  <MockedProvider mocks={[mockOperationFromPool(mocks, AwardByIdQuery)]}>
+  <MockedProvider mocks={[mocks.mockOperation(AwardByIdQuery)]}>
     <AwardCard />
   </MockedProvider>,
 );
 ```
 
-Prefer to supply the data yourself? `mockOperation` takes the result data directly; the result/variables types are inferred from the document, so `data` is type-checked against the operation's result type:
+Prefer to supply the data yourself? The standalone `mockOperation` takes the result data directly; the result/variables types are inferred from the document, so `data` is type-checked against the operation's result type:
 
 ```ts
 import { mockOperation } from '@vantreeseba/graphql-mocks';
@@ -152,19 +152,17 @@ mockOperation(AwardByIdQuery, { award: mockAwards[0], __typename: 'Query' });
 By default a mock matches **any** variables and may be used any number of times (`maxUsageCount: Infinity`). Override per call when you need exact matching, a delay, or an error (the same `options` apply to every helper here):
 
 ```ts
-mockOperationFromPool(mocks, AwardByIdQuery, {
+mocks.mockOperation(AwardByIdQuery, {
   variables: { id: 'Award-0' }, // exact match (or a predicate (vars) => boolean)
   delay: 50,
   maxUsageCount: 1,
 });
 ```
 
-For the common "success / loading / error" trio, `mockOperationVariants` (data passed in) and `mockOperationVariantsFromPool` (data from the graph) return all three at once:
+For the common "success / loading / error" trio, `mockOperationVariants` returns all three at once — `mocks.mockOperationVariants` resolves the success data from the graph, while the standalone `mockOperationVariants(operation, data)` takes it directly:
 
 ```ts
-import { mockOperationVariantsFromPool } from '@vantreeseba/graphql-mocks';
-
-const m = mockOperationVariantsFromPool(mocks, AwardByIdQuery);
+const m = mocks.mockOperationVariants(AwardByIdQuery);
 m.withResults;      // resolves with data drawn from the pool
 m.withLongLoadTime; // stays pending — drive loading states
 m.withError;        // rejects with an error naming the operation

--- a/packages/graphql-mocks/src/apolloMocks.ts
+++ b/packages/graphql-mocks/src/apolloMocks.ts
@@ -1,12 +1,12 @@
 import type { TypedDocumentNode } from '@graphql-typed-document-node/core';
 import { type DocumentNode, Kind } from 'graphql';
-import type { MockResult } from './types.js';
 
-/** The subset of a `MockResult` these helpers need: the operation resolver. */
-type OperationDataSource = Pick<MockResult, 'dataForOperation'>;
-
-/** Concrete variables for data resolution (a matcher function can't drive pool selection). */
-function variablesForData<TVars>(
+/**
+ * Reduce `options.variables` to concrete variables for pool-based data resolution: a matcher
+ * function decides which mock *matches*, but it can't drive which mocks are *selected*, so it
+ * resolves to `undefined` (required variables are auto-filled during execution).
+ */
+export function variablesForData<TVars>(
   variables: TVars | VariableMatcher<TVars> | undefined,
 ): TVars | undefined {
   return typeof variables === 'function' ? undefined : variables;
@@ -141,36 +141,4 @@ export function mockOperationVariants<TData, TVars>(
         ),
     }),
   };
-}
-
-/**
- * Like {@link mockOperation}, but the result data is resolved automatically from a
- * `MockResult` pool (via `mocks.dataForOperation`) instead of being passed in — the query's
- * selection set selects matching mocks from the graph.
- *
- * ```ts
- * const mocks = buildMocks(schema);
- * const awardMock = mockOperationFromPool(mocks, AwardByIdQuery);
- * ```
- */
-export function mockOperationFromPool<TData, TVars>(
-  mocks: OperationDataSource,
-  operation: TypedDocumentNode<TData, TVars>,
-  options: MockOperationOptions<TVars> = {},
-): MockedResponse<TData, TVars> {
-  const data = mocks.dataForOperation(operation, variablesForData(options.variables) as never);
-  return mockOperation(operation, data, options);
-}
-
-/**
- * Like {@link mockOperationVariants}, but the success data is resolved automatically from a
- * `MockResult` pool instead of being passed in.
- */
-export function mockOperationVariantsFromPool<TData, TVars>(
-  mocks: OperationDataSource,
-  operation: TypedDocumentNode<TData, TVars>,
-  options: MockOperationOptions<TVars> = {},
-): MockOperationVariants<TData, TVars> {
-  const data = mocks.dataForOperation(operation, variablesForData(options.variables) as never);
-  return mockOperationVariants(operation, data, options);
 }

--- a/packages/graphql-mocks/src/executeOperation.test.ts
+++ b/packages/graphql-mocks/src/executeOperation.test.ts
@@ -80,3 +80,44 @@ describe('dataForOperation', () => {
     expect(data.user?.id).toBeDefined();
   });
 });
+
+type UserData = { user: { id: string } | null };
+type UserVars = { id: string };
+const UserByIdQuery = parse(
+  'query UserById($id: ID!) { user(id: $id) { id } }',
+) as TypedDocumentNode<UserData, UserVars>;
+
+describe('mocks.mockOperation', () => {
+  it('builds a MockedProvider entry with data resolved from the pool — no data argument', () => {
+    const mock = mocks.mockOperation(UserByIdQuery);
+    expect(mock.request.query).toBe(UserByIdQuery);
+    expect(mock.result?.data?.user?.id).toBeDefined();
+    // The resolved id is a real pooled instance.
+    expect(mocks.User?.some((u) => (u as { id: string }).id === mock.result?.data?.user?.id)).toBe(
+      true,
+    );
+  });
+
+  it('defaults variables to a match-any predicate and maxUsageCount to Infinity', () => {
+    const mock = mocks.mockOperation(UserByIdQuery);
+    expect(typeof mock.request.variables).toBe('function');
+    expect(mock.maxUsageCount).toBe(Number.POSITIVE_INFINITY);
+  });
+
+  it('threads delay/error/maxUsageCount options through', () => {
+    const error = new Error('boom');
+    const mock = mocks.mockOperation(UserByIdQuery, { delay: 50, error, maxUsageCount: 2 });
+    expect(mock.delay).toBe(50);
+    expect(mock.error).toBe(error);
+    expect(mock.maxUsageCount).toBe(2);
+  });
+});
+
+describe('mocks.mockOperationVariants', () => {
+  it('returns success/long-load/error variants, success data drawn from the pool', () => {
+    const variants = mocks.mockOperationVariants(UserByIdQuery);
+    expect(variants.withResults.result?.data?.user?.id).toBeDefined();
+    expect(variants.withLongLoadTime.delay).toBe(1_000_000);
+    expect(variants.withError.error?.message).toContain('UserById');
+  });
+});

--- a/packages/graphql-mocks/src/graphBuilder.ts
+++ b/packages/graphql-mocks/src/graphBuilder.ts
@@ -8,6 +8,12 @@ import {
   isScalarType,
   isUnionType,
 } from 'graphql';
+import {
+  type MockOperationOptions,
+  mockOperation as buildMockOperation,
+  mockOperationVariants as buildMockOperationVariants,
+  variablesForData,
+} from './apolloMocks.js';
 import { resolveOperationData } from './executeOperation.js';
 import { OPERATION_TYPE_NAMES, resolveCount, resolveFaker } from './helpers.js';
 import { mockTypeScalars, unwrapType } from './typeMocker.js';
@@ -33,23 +39,44 @@ function createMockResult(
   schema: GraphQLSchema,
   options: BuildMocksOptions,
 ): MockResult {
+  const dataForOperation = (
+    document: Parameters<typeof resolveOperationData>[4],
+    variables?: Record<string, unknown>,
+  ) =>
+    resolveOperationData(
+      schema,
+      pool as Record<string, Record<string, unknown>[]>,
+      faker,
+      options,
+      document,
+      variables,
+    );
+
   const helpers = {
     find<T = unknown>(typeName: string, predicate: (item: T) => boolean): T | undefined {
       const items = pool[typeName] as T[] | undefined;
       return items?.find(predicate);
     },
-    dataForOperation(
-      document: Parameters<typeof resolveOperationData>[4],
-      variables?: Record<string, unknown>,
+    dataForOperation,
+    mockOperation(
+      document: Parameters<typeof buildMockOperation>[0],
+      opOptions: MockOperationOptions = {},
     ) {
-      return resolveOperationData(
-        schema,
-        pool as Record<string, Record<string, unknown>[]>,
-        faker,
-        options,
+      const data = dataForOperation(
         document,
-        variables,
+        variablesForData(opOptions.variables) as Record<string, unknown> | undefined,
       );
+      return buildMockOperation(document, data, opOptions);
+    },
+    mockOperationVariants(
+      document: Parameters<typeof buildMockOperationVariants>[0],
+      opOptions: MockOperationOptions = {},
+    ) {
+      const data = dataForOperation(
+        document,
+        variablesForData(opOptions.variables) as Record<string, unknown> | undefined,
+      );
+      return buildMockOperationVariants(document, data, opOptions);
     },
     toResolvers(): Record<string, () => unknown> {
       const resolvers: Record<string, () => unknown> = {};

--- a/packages/graphql-mocks/src/index.ts
+++ b/packages/graphql-mocks/src/index.ts
@@ -1,9 +1,4 @@
-export {
-  mockOperation,
-  mockOperationFromPool,
-  mockOperationVariants,
-  mockOperationVariantsFromPool,
-} from './apolloMocks.js';
+export { mockOperation, mockOperationVariants } from './apolloMocks.js';
 export type {
   MockedResponse,
   MockOperationOptions,

--- a/packages/graphql-mocks/src/types.ts
+++ b/packages/graphql-mocks/src/types.ts
@@ -1,6 +1,7 @@
 import type { Faker } from '@faker-js/faker';
 import type { TypedDocumentNode } from '@graphql-typed-document-node/core';
 import type { DocumentNode } from 'graphql';
+import type { MockOperationOptions, MockOperationVariants, MockedResponse } from './apolloMocks.js';
 
 export type ScalarMocker = (faker: Faker) => unknown;
 /**
@@ -110,6 +111,31 @@ export interface MockHelpers<TTypes extends Record<string, unknown> = Record<str
     document: TypedDocumentNode<TData, TVars> | DocumentNode,
     variables?: TVars extends Record<string, unknown> ? Partial<TVars> : Record<string, unknown>,
   ): TData;
+  /**
+   * Build an Apollo `MockedProvider` entry for the operation with **no data argument** — the
+   * result is resolved straight from this graph via {@link MockHelpers.dataForOperation}, so the
+   * query's own selection set decides which mocks come back. The pool is captured, so you only
+   * pass the document (and optional `variables`/`delay`/`error`/`maxUsageCount` overrides).
+   *
+   * ```ts
+   * const mocks = buildMocks(schema);
+   * <MockedProvider mocks={[mocks.mockOperation(AwardByIdQuery)]}>…</MockedProvider>
+   * ```
+   *
+   * To supply the data yourself instead, use the standalone `mockOperation(operation, data)`.
+   */
+  mockOperation<TData = unknown, TVars = Record<string, unknown>>(
+    operation: TypedDocumentNode<TData, TVars>,
+    options?: MockOperationOptions<TVars>,
+  ): MockedResponse<TData, TVars>;
+  /**
+   * Like {@link MockHelpers.mockOperation}, but returns the success / long-load / error trio at
+   * once, with the success data resolved from this graph.
+   */
+  mockOperationVariants<TData = unknown, TVars = Record<string, unknown>>(
+    operation: TypedDocumentNode<TData, TVars>,
+    options?: MockOperationOptions<TVars>,
+  ): MockOperationVariants<TData, TVars>;
   /**
    * Build a resolver map keyed by type name, each returning a random pooled instance.
    * Type names declared in `TTypes` come back typed (`resolvers.User()` is `TTypes['User']`)


### PR DESCRIPTION
## Summary

Makes the result data optional for building Apollo `MockedProvider` entries: `mockOperation`/`mockOperationVariants` are now methods on the `MockResult` graph that resolve data straight from the pool via `dataForOperation`. The query's own selection set decides which mocks come back — no data argument needed.

```ts
const mocks = buildMocks(schema);
mocks.mockOperation(AwardByIdQuery);                 // data resolved from the graph
mocks.mockOperation(AwardByIdQuery, { delay: 50 });  // + variables/error/maxUsageCount
mocks.mockOperationVariants(AwardByIdQuery);         // success/loading/error trio

mockOperation(AwardByIdQuery, data);                 // standalone, explicit data (unchanged)
```

## Changes

- `graphBuilder.ts` — `MockResult` now exposes `mockOperation` / `mockOperationVariants`, each resolving via the captured `dataForOperation` and delegating to the standalone builders.
- `apolloMocks.ts` — removed `mockOperationFromPool` / `mockOperationVariantsFromPool`; exported `variablesForData` for reuse.
- `types.ts` — added the two methods to `MockHelpers` (generic, return types inferred from the `TypedDocumentNode`).
- `index.ts` — dropped the `FromPool` exports.
- Tests — added coverage for the new methods (pool resolution, defaults, option threading, variants trio).
- Docs — `README.md` and `llms.txt` updated to the curried API.

## Breaking change

`mockOperationFromPool` and `mockOperationVariantsFromPool` are removed. Replace `mockOperationFromPool(mocks, query)` with `mocks.mockOperation(query)` (same for variants).

## Testing

- `npm test` — 134 + 13 passing
- `npm run typecheck` — clean
- `npm run check` (biome) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)